### PR TITLE
Add .wp to the bypassed domains list

### DIFF
--- a/hmproxy
+++ b/hmproxy
@@ -419,7 +419,7 @@ enable_proxy_settings() {
 
 		networksetup -setsocksfirewallproxy "$MAINSERVICE" "127.0.0.1" "9050" off
 		networksetup -setsocksfirewallproxystate "$MAINSERVICE" on
-		networksetup -setproxybypassdomains "$MAINSERVICE" "*.dev" "*.local" "169.254/16" "localhost" "127.0.0.1"
+		networksetup -setproxybypassdomains "$MAINSERVICE" "*.dev" "*.local" "*.wp" "169.254/16" "localhost" "127.0.0.1"
 	fi
 
 	if [[ ! -z "$GITHUB" ]]; then


### PR DESCRIPTION
I use `.wp` as the tld for my local WordPress dev sites.
