### PR TITLE
Fix symlink command documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,13 @@ To install:
 
 To make it available everywhere:
 * `cd` into the `hmproxy` directory
-* `ln -s $PWD/hmproxy /usr/local/bin`
+* `ln -s $PWD/hmproxy /usr/local/bin/hmproxy`
 
+If the `/usr/local/bin` directory does not exist yet you can create it first by running the following command:
+
+```
+sudo mkdir /usr/local/bin
+```
 
 ## Examples
 


### PR DESCRIPTION
On OSX and possibly other linux distros the `/usr/local/bin` directory does not exist by default.

As a result if someone runs `ln -s $PWD/hmproxy /usr/local/bin` then you get `/usr/local/bin` itself symlinked directly to `hmproxy`. Not ideal!