### PR TITLE
Avoid overwriting SSH config with blank file

### DIFF
--- a/hmproxy
+++ b/hmproxy
@@ -465,7 +465,7 @@ disable_proxy_settings() {
 		networksetup -setsocksfirewallproxystate "$MAINSERVICE" off
 	fi
 
-	sed '/## <HMProxy>/,/## <\/HMProxy>/d' ~/.ssh/config > ~/.ssh/config
+	sed -i '' '/## <HMProxy>/,/## <\/HMProxy>/d' ~/.ssh/config
 
 	# Don't run again
 	DID_DISABLE=1


### PR DESCRIPTION
Fixes #11

Unsure why we never fixed this before! Seems like it only occurs on some setups.